### PR TITLE
Add "jquery:deprecated" config set

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,4 +31,36 @@ module.exports = {
     'no-val': require('./rules/no-val'),
     'no-wrap': require('./rules/no-wrap')
   }
+  configs: {
+    deprecated: {
+      "jquery/no-ajax": 2,
+      "jquery/no-attr": 2,
+      "jquery/no-bind": 2,
+      "jquery/no-class": 2,
+      "jquery/no-clone": 2,
+      "jquery/no-closest": 2,
+      "jquery/no-css": 2,
+      "jquery/no-data": 2,
+      "jquery/no-deferred": 2,
+      "jquery/no-delegate": 2,
+      "jquery/no-each": 2,
+      "jquery/no-find": 2,
+      "jquery/no-global-eval": 2,
+      "jquery/no-html": 2,
+      "jquery/no-in-array": 2,
+      "jquery/no-is": 2,
+      "jquery/no-map": 2,
+      "jquery/no-merge": 2,
+      "jquery/no-param": 2,
+      "jquery/no-parent": 2,
+      "jquery/no-parents": 2,
+      "jquery/no-prop": 2,
+      "jquery/no-serialize": 2,
+      "jquery/no-text": 2,
+      "jquery/no-trigger": 2,
+      "jquery/no-trim": 2,
+      "jquery/no-val": 2,
+      "jquery/no-wrap": 2
+    }
+  }
 }


### PR DESCRIPTION
People can add `extends: "jquery:deprecated"` to their `.eslintrc.json` to get this default set.

-
To: @dgraham